### PR TITLE
Reflect lavalink position changes in players

### DIFF
--- a/lib/src/event_dispatcher.dart
+++ b/lib/src/event_dispatcher.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:nyxx/nyxx.dart';
-import 'package:nyxx_lavalink/src/model/track.dart';
-
 import 'cluster.dart';
+
 import 'model/stats.dart';
+import 'model/track.dart';
 import 'model/track_end.dart';
 import 'model/track_start.dart';
 import 'model/track_stuck.dart';

--- a/lib/src/event_dispatcher.dart
+++ b/lib/src/event_dispatcher.dart
@@ -135,8 +135,8 @@ class EventDispatcher implements IEventDispatcher {
 
         if (update.state.position != null) {
           final _node = node as Node;
-          (_node.players[update.guildId]?.nowPlaying?.track.info as TrackInfo)
-              .position = update.state.position!;
+          // Update the position of the currently playing track of the corresponding player.
+          (_node.players[update.guildId]?.nowPlaying?.track.info as TrackInfo).position = update.state.position!;
         }
 
         onPlayerUpdateController.add(update);

--- a/lib/src/event_dispatcher.dart
+++ b/lib/src/event_dispatcher.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:nyxx/nyxx.dart';
+import 'package:nyxx_lavalink/src/model/track.dart';
 
 import 'cluster.dart';
 import 'model/stats.dart';
@@ -130,7 +131,15 @@ class EventDispatcher implements IEventDispatcher {
         break;
 
       case "playerUpdate":
-        onPlayerUpdateController.add(PlayerUpdateEvent(cluster.client, node, json["data"] as Map<String, dynamic>));
+        final update = PlayerUpdateEvent(cluster.client, node, json["data"] as Map<String, dynamic>);
+
+        if (update.state.position != null) {
+          final _node = node as Node;
+          (_node.players[update.guildId]?.nowPlaying?.track.info as TrackInfo)
+              .position = update.state.position!;
+        }
+
+        onPlayerUpdateController.add(update);
         break;
     }
   }

--- a/lib/src/event_dispatcher.dart
+++ b/lib/src/event_dispatcher.dart
@@ -136,7 +136,7 @@ class EventDispatcher implements IEventDispatcher {
         if (update.state.position != null) {
           final _node = node as Node;
           // Update the position of the currently playing track of the corresponding player.
-          (_node.players[update.guildId]?.nowPlaying?.track.info as TrackInfo).position = update.state.position!;
+          (_node.players[update.guildId]?.nowPlaying?.track.info as TrackInfo?)?.position = update.state.position!;
         }
 
         onPlayerUpdateController.add(update);

--- a/lib/src/model/track.dart
+++ b/lib/src/model/track.dart
@@ -125,7 +125,7 @@ class TrackInfo implements ITrackInfo {
 
   /// Position returned by lavalink
   @override
-  late final int position;
+  late int position;
 
   /// The title of the track
   @override


### PR DESCRIPTION
# Description

This PR updates the corresponding guild player now playing track position before emitting the player update event to reflect lavalink latest sent position in the player.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
