### PR TITLE
Fix non-latin characters

### DIFF
--- a/lib/src/node/node.dart
+++ b/lib/src/node/node.dart
@@ -277,7 +277,7 @@ class Node implements INode {
       throw HttpException(response.statusCode);
     }
 
-    return Tracks(jsonDecode(response.body) as Map<String, dynamic>);
+    return Tracks(jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>);
   }
 
   /// Searches a provided query on selected platform (YouTube by default),


### PR DESCRIPTION
# Description
The previous implementation was using `body` getter, that converts `bodyBytes` to latin1, however, latin1 doesn't support kanjis, Cyrillic etc.. Which can lead to these kind of strings; `"å¤éè®æ­"`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
